### PR TITLE
Remove strict Windows dependency for a node package in client packages

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -12,7 +12,7 @@
 				"@electron/asar": "^3.3.1",
 				"@radix-ui/react-switch": "^1.1.3",
 				"@tabler/icons-react": "^3.30.0",
-				"@tailwindcss/oxide-win32-x64-msvc": "^4.1.1",
+				"@tailwindcss/oxide": "^4.1.1",
 				"@tailwindcss/postcss": "^4.0.7",
 				"@tsparticles/engine": "^3.8.1",
 				"@tsparticles/react": "^3.0.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -19,7 +19,7 @@
 		"@electron/asar": "^3.3.1",
 		"@radix-ui/react-switch": "^1.1.3",
 		"@tabler/icons-react": "^3.30.0",
-		"@tailwindcss/oxide-win32-x64-msvc": "^4.1.1",
+		"@tailwindcss/oxide": "^4.1.1",
 		"@tailwindcss/postcss": "^4.0.7",
 		"@tsparticles/engine": "^3.8.1",
 		"@tsparticles/react": "^3.0.0",


### PR DESCRIPTION
### 🚀 Summary
The package @tailwindcss/oxide in package.json in the client side requisites was previously forced to install the Win32 version. This generates an error on installation on Linux systems, preventing package installation because the OS does not match. Considering that the project announces that the installation steps are, in fact, for installing on a Linux system, this is counterintuitive.
Simply removing the "-Win32" prefix allows Node to automatically install the package based on the actual OS.

### ✅ Related Issues
Closes #issue_number (if applicable).

### 🔍 Changes Made
- [x] Bugfix 🐛
- [ ] Feature 🚀
- [ ] Refactor ♻️

### 📸 Screenshots (if applicable)
Without this change, `npm install` will fail the error mentioned below

```bash
root@aihorde:~/Sentient/src/client# npm install
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @tailwindcss/oxide-win32-x64-msvc@4.1.1: wanted {"os":"win32","cpu":"x64"} (current: {"os":"linux","cpu":"x64"})
npm error notsup Valid os:   win32
npm error notsup Actual os:  linux
npm error notsup Valid cpu:  x64
npm error notsup Actual cpu: x64
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-07-05T18_00_09_876Z-debug-0.log
``` 

### 💡 How to Test?
setup a brand new Linux VM, like a Ubuntu 24.04 VM.
Following the first steps to selfhost the project, clone the repository, [install Node](https://nodejs.org/en/download), do `cd Sentient/src/client && npm install`. Everything should go correctly with this patch.

### 🔄 Additional Context
N/A